### PR TITLE
Fix two bugs in eval code

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -35,7 +35,7 @@ def network(eval_model, device):
     return net
 
 if __name__ == "__main__":
-    imgpath = './test_imgs/1.jpg'                         # [1,2,3.jpg]
+    imgpath = './demo_imgs/1.jpg'                         # [1,2,3.jpg]
     device = 'cpu'                                        # 'cpu' or 'cuda:x'
     eval_model = './model/SDD_FIQA_checkpoints_r50.pth'   # checkpoint
     net = network(eval_model, device)

--- a/generate_pseudo_labels/extract_embedding/model/model.py
+++ b/generate_pseudo_labels/extract_embedding/model/model.py
@@ -158,5 +158,5 @@ def R50(input_size, use_type = "Rec"):
     if use for quality network, select self.use_type == "Qua"
     if use for recognition network, select self.use_type == "Rec"
     '''
-    model = Backbone(input_size, 50, 'ir', use_type = "Rec")
+    model = Backbone(input_size, 50, 'ir', use_type = use_type)
     return model


### PR DESCRIPTION
Details

```
Traceback (most recent call last):
  File "eval.py", line 41, in <module>
    net = network(eval_model, device)
  File "eval.py", line 33, in network
    net.load_state_dict(net_dict)
  File "/home/jh/anaconda3/lib/python3.7/site-packages/torch/nn/modules/module.py", line 1224, in load_state_dict
    self.__class__.__name__, "\n\t".join(error_msgs)))
RuntimeError: Error(s) in loading state_dict for Backbone:
	Unexpected key(s) in state_dict: "quality.1.weight", "quality.3.weight", "quality.3.bias". 
```

```
Traceback (most recent call last):
  File "eval.py", line 42, in <module>
    input_data = read_img(imgpath)
  File "eval.py", line 22, in read_img
    img = Image.open(imgPath).convert("RGB")
  File "/home/jh/anaconda3/lib/python3.7/site-packages/PIL/Image.py", line 2912, in open
    fp = builtins.open(filename, "rb")
FileNotFoundError: [Errno 2] No such file or directory: './test_imgs/1.jpg'
```