### PR TITLE
Fix CUDA/CPU device mismatch in `quality/eval.py`

### DIFF
--- a/quality/eval.py
+++ b/quality/eval.py
@@ -12,15 +12,15 @@ import pdb
 from PIL import Image
 
 
-def read_img(imgPath):     # read image & data pre-process
-    data = torch.randn(1, 3, 112, 112)
+def read_img(imgPath, device):     # read image & data pre-process
+    data = torch.randn(1, 3, 112, 112).to(device)
     transform = T.Compose([
         T.Resize((112, 112)),
         T.ToTensor(),
         T.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5]),
     ])
     img = Image.open(imgPath).convert("RGB")
-    data[0, :, :, :] = transform(img)
+    data[0, :, :, :] = transform(img).to(device)
     return data
 
 
@@ -36,9 +36,9 @@ def network(eval_model, device):
 
 if __name__ == "__main__":
     imgpath = './demo_imgs/1.jpg'                         # [1,2,3.jpg]
-    device = 'cpu'                                        # 'cpu' or 'cuda:x'
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
     eval_model = './model/SDD_FIQA_checkpoints_r50.pth'   # checkpoint
     net = network(eval_model, device)
-    input_data = read_img(imgpath)
+    input_data = read_img(imgpath, device)
     pred_score = net(input_data).data.cpu().numpy().squeeze()
     print(f"Quality score = {pred_score}")


### PR DESCRIPTION
When running `quality/eval.py` with `device="cuda"`, the following error occurred on line 43:

```python
pred_score = net(input_data).data.cpu().numpy().squeeze()
```

```
RuntimeError: Input type (torch.FloatTensor) and weight type (torch.cuda.FloatTensor) should be the same or input should be a MKLDNN tensor and weight is a dense tensor
```

This error occurred because the model was on `cuda` but the `input_data` was on `cpu`.

### Changes made to resolve the issue:

1. Modified `read_img` function to accept a device parameter and move the input tensor to the specified device.
2. Updated the `device` selection in the main script to use `torch.device()` with a check for CUDA availability.
3. Ensured that the input data is moved to the same device as the model before forward pass.

These changes ensure that both the model and input data are on the same device, resolving the CUDA/CPU mismatch error.